### PR TITLE
7:  確認ダイアログを制御するモジュールを作成

### DIFF
--- a/modules/util/confirmDialog.ts
+++ b/modules/util/confirmDialog.ts
@@ -1,0 +1,60 @@
+import { reactive } from '@nuxtjs/composition-api'
+
+type Operations = 'create' | 'update' | 'delete' | 'cancel' | 'retry'
+
+interface ConfirmDialog {
+  isOpened: boolean
+  confirmType: Operations
+  onOk: () => any
+  onCancel: () => any
+}
+
+export const useConfirmDialog = () => {
+  // OKボタン押下時のデフォルトの処理
+  const DEFAULT_ON_OK = () => {}
+
+  // キャンセルボタン押下時のデフォルトの処理
+  const DEFAULT_ON_CANCEL = () => {
+    confirmDialog.isOpened = false
+  }
+  const DEFAULT_CONFIRM_TYPE: Operations = 'create'
+
+  /**
+   * 確認ダイアログの開閉フラグと、ボタン押下時の処理を持つReactiveオブジェクト
+   */
+  const confirmDialog = reactive<ConfirmDialog>({
+    isOpened: false,
+    confirmType: DEFAULT_CONFIRM_TYPE,
+    onOk: DEFAULT_ON_OK,
+    onCancel: DEFAULT_ON_CANCEL
+  })
+
+  /**
+   * 確認ダイアログの開閉フラグをtrueにする。
+   * 引数として、OK/キャンセルボタン押下時の処理を受け取る。
+   * @param onOk ダイアログのOK押下時に実行する関数
+   * @param onCancel ダイアログのキャンセル押下時に実行する関数
+   */
+  const openConfirmDialog = (type: Operations, onOk: () => any, onCancel: () => any = DEFAULT_ON_CANCEL) => {
+    confirmDialog.confirmType = type
+    confirmDialog.onOk = onOk
+    confirmDialog.onCancel = onCancel
+    confirmDialog.isOpened = true
+  }
+
+  /**
+   * 確認ダイアログのを閉じる。
+   * ボタン押下時に実行する関数をクリアする。
+   */
+  const closeConfirmDialog = () => {
+    confirmDialog.isOpened = false
+    confirmDialog.onOk = DEFAULT_ON_OK
+    confirmDialog.onCancel = DEFAULT_ON_CANCEL
+  }
+
+  return {
+    confirmDialog,
+    openConfirmDialog,
+    closeConfirmDialog
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nuxtjs/eslint-module": "^3.0.2",
     "@nuxtjs/pwa": "^3.3.5",
     "@nuxtjs/vuetify": "^1.12.1",
+    "@types/jest": "^26.0.24",
     "@vue/test-utils": "^1.2.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^27.0.5",

--- a/test/util/confirmDialog.spec.ts
+++ b/test/util/confirmDialog.spec.ts
@@ -1,0 +1,41 @@
+import { useConfirmDialog } from '~/modules/util/confirmDialog'
+
+describe('ユニットテスト: confirmDialog', () => {
+  /** ダイアログを開く => okボタンを押す */
+  test('openConfirmDialogで渡した関数が、confirmDialog.onOK()で実行される', () => {
+    const { confirmDialog, openConfirmDialog } = useConfirmDialog()
+
+    const mockFuncOk = jest.fn(() => {})
+
+    openConfirmDialog('create', mockFuncOk)
+    confirmDialog.onOk()
+    expect(mockFuncOk).toHaveBeenCalled()
+  })
+
+  /** ダイアログを開く => cancelボタンを押す */
+  test('openConfirmDialogで第三引数に渡した関数が、confirmDialog.onCancel()で実行される', () => {
+    const { confirmDialog, openConfirmDialog } = useConfirmDialog()
+    const mockFuncOk = jest.fn(() => {})
+    const mockFuncCancel = jest.fn(() => [])
+
+    openConfirmDialog('cancel', mockFuncOk, mockFuncCancel)
+    confirmDialog.onCancel()
+    expect(mockFuncCancel).toHaveBeenCalled()
+  })
+
+  /** ダイアログを開く */
+  test('openConfirmDialogを実行して確認ダイアログを開く', () => {
+    const { confirmDialog, openConfirmDialog } = useConfirmDialog()
+
+    const func = () => {}
+    openConfirmDialog('create', func)
+    expect(confirmDialog.isOpened).toEqual(true)
+  })
+
+  /** ダイアログを閉じる */
+  test('closeConfirmDialogを実行して確認ダイアログを閉じる', () => {
+    const { confirmDialog, closeConfirmDialog } = useConfirmDialog()
+    closeConfirmDialog()
+    expect(confirmDialog.isOpened).toEqual(false)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
       "~/*": ["./*"],
       "@/*": ["./*"]
     },
-    "types": ["@nuxt/types", "@types/node", "nuxt-i18n", "@nuxtjs/sentry"]
+    "types": ["@nuxt/types", "@types/node", "nuxt-i18n", "@nuxtjs/sentry", "@types/jest"]
   },
   "exclude": ["node_modules", ".nuxt", "dist"],
   "vetur.ignoreProjectWarning": true


### PR DESCRIPTION
# レビュー観点
- `create`や`cancel`などの目的に応じて、ダイアログの制御ができているか
- テストが実装されていてエラーは出てないか
- テスト実施項目は適切か
# 動作確認実施項目
- [x] `create`や`cancel`などの目的に応じて、ダイアログの制御ができている
- [x] テストが実装されていてエラーは出てない
- [x] テスト項目は適切
# 未実施項目
- 確認ダイアログコンポーネントが未実装のため繋ぎこみは未実装
# その他
- テストで動作確認を実施